### PR TITLE
File open/close for every writing v1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+
+Code/files/2023-7-12-11-33-25.csv
+Code/files/2023-7-12-11-33-38.csv
+Code/files/2023-7-12-11-33-40.csv
+Code/lemmingometre/pandas_data_reading_test.py

--- a/Code/lemmingometre/lemmingometre.ino
+++ b/Code/lemmingometre/lemmingometre.ino
@@ -12,7 +12,7 @@ int chipSelect = D8;  //SD card
 int obstacleSensor = D4;
 
 ///// DATA VARIABLES /////
-int obstacle_acquisition_time = 30000;
+int obstacle_acquisition_time = 10000;
 int obstacleValue;
 DateTime now;
 
@@ -75,7 +75,7 @@ void setupSD() {
 
 void setFileName() {
   DateTime now = rtc.now();
-  snprintf(filename, 50, "%d-%d-%d-%d-%d-%d.txt", now.year(), now.month(), now.day(), now.hour(), now.minute(), now.second());
+  snprintf(filename, 50, "%d-%d-%d-%d-%d-%d.csv", now.year(), now.month(), now.day(), now.hour(), now.minute(), now.second());
 }
 
 


### PR DESCRIPTION
To save data in a file, it needs to be closed. It is likely that the Wemos will reset before the acquisition is over. If the file is only closed after the acquisition delay, no file will be created if a reset is triggered before the acquisition delay.